### PR TITLE
Fixes for gcc and c++11

### DIFF
--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -49,9 +49,9 @@ class TSlotMap
 {
     // Compile time pow function
     template <typename T>
-    static inline constexpr T POW(const T base, const unsigned int exponent)
+    static constexpr T POW(const T base, const unsigned int exponent)
     {
-        return exponent == 0 ? 1 : (base * POW(base, exponent - 1));
+        return (exponent == 0) ? 1 : (base * POW(base, exponent - 1));
     }
 
 public:

--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -31,7 +31,7 @@
 
 #include <type_traits>
 #include <cstring>
-#include <assert.h>
+#include <cassert>
 
 // Slot-Map data-structure with O(1) insert, erase and fast iteration/lookup
 // @Value: Type of data contained in this slot map.

--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -44,11 +44,11 @@
 // @INVALID_KEY_: It is guaranteed that this key will never be generated and can safely be used to represent something like INVALID. Currently it's value the same as: std::numeric_limit<Key>::max()
 // @SizeType: Type for the erase-table. The slot-map can not contain more entries than the number of elements this number can represent.
 // NOTE: INDEX_BIT_COUNT_ + GENERATION_BIT_COUNT_ MUST be equal to the amount of bits in Key. (Ensured by static assert)
-template<typename Value, typename Key = uint64_t, unsigned int INDEX_BIT_COUNT_ = 32, unsigned int GENERATION_BIT_COUNT_ = 32, Key INVALID_KEY_ = ~Key{0}, typename SizeType = unsigned int>
+template <typename Value, typename Key = uint64_t, unsigned int INDEX_BIT_COUNT_ = 32, unsigned int GENERATION_BIT_COUNT_ = 32, Key INVALID_KEY_ = ~Key{0}, typename SizeType = unsigned int>
 class TSlotMap
 {
     // Compile time pow function
-    template<typename T>
+    template <typename T>
     static inline constexpr T POW(const T base, const unsigned int exponent)
     {
         return exponent == 0 ? 1 : (base * POW(base, exponent - 1));
@@ -107,7 +107,7 @@ public:
         return emplace_back(std::move(_Val));
     }
 
-    template<class... Values>
+    template <class... Values>
     Key emplace_back(Values&&... vals)
     {
         // Map is full, allocate more memory
@@ -423,13 +423,13 @@ private:
     }
 
     //////////////////////////////////////////////////////////////////////////////
-    template<typename T>
+    template <typename T>
     inline typename std::enable_if<std::is_move_constructible<T>::value>::type _MoveConstructObject(T* dst, IndexType indexToStore, T* src, IndexType indexToMove)
     {
         new (std::addressof(dst[indexToStore])) T(std::move(src[indexToMove]));
     }
 
-    template<typename T>
+    template <typename T>
     inline typename std::enable_if<!std::is_move_constructible<T>::value>::type _MoveConstructObject(T* dst, IndexType indexToStore, T* src, IndexType indexToMove)
     {
         new (std::addressof(dst[indexToStore])) T(src[indexToMove]);

--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -215,7 +215,7 @@ public:
         IndexType dataIndex = _GetIndex(m_IndicesAndGeneration[index]);
         return std::addressof(m_Data[dataIndex]);
     }
-    const Value* at(Key key) const { return at(key); }
+    const Value* at(Key key) const { return const_cast<TSlotMap*>(this)->at(key); }
 
     Value*       operator[] (Key key)       { return at(key); }
     const Value* operator[] (Key key) const { return at(key); }

--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -4,6 +4,7 @@
 
     author: S. Hau
     date: December 31, 2018
+    repository: https://github.com/SilvanVR/SlotMap
 
     Similar to a std::map but about ~10-100x faster.
     [+] Data stored contigously in memory.

--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -38,12 +38,12 @@
 // Slot-Map data-structure with O(1) insert, erase and fast iteration/lookup
 // @Value: Type of data contained in this slot map.
 // @Key: Type is used as a key and contains the Index for the data array and a generation counter (to solve ABA problem)
-// @INDEX_BIT_COUNT: Number of bits for the index into the index map. This specifies an upper limit for the entry count.
-// @GENERATION_BIT_COUNT: Number of bits for the generation. If this value is too low, ABA problem is more likely to happen.
-// @INVALID_KEY: It is guaranteed that this key will never be generated and can safely be used to represent something like INVALID. Currently it's value the same as: std::numeric_limit<Key>::max()
+// @INDEX_BIT_COUNT_: Number of bits for the index into the index map. This specifies an upper limit for the entry count.
+// @GENERATION_BIT_COUNT_: Number of bits for the generation. If this value is too low, ABA problem is more likely to happen.
+// @INVALID_KEY_: It is guaranteed that this key will never be generated and can safely be used to represent something like INVALID. Currently it's value the same as: std::numeric_limit<Key>::max()
 // @SizeType: Type for the erase-table. The slot-map can not contain more entries than the number of elements this number can represent.
-// NOTE: INDEX_BIT_COUNT + GENERATION_BIT_COUNT MUST be equal to the amount of bits in Key. (Ensured by static assert)
-template<typename Value, typename Key = uint64_t, unsigned int INDEX_BIT_COUNT = 32, unsigned int GENERATION_BIT_COUNT = 32, Key INVALID_KEY = ~Key{0}, typename SizeType = unsigned int>
+// NOTE: INDEX_BIT_COUNT_ + GENERATION_BIT_COUNT_ MUST be equal to the amount of bits in Key. (Ensured by static assert)
+template<typename Value, typename Key = uint64_t, unsigned int INDEX_BIT_COUNT_ = 32, unsigned int GENERATION_BIT_COUNT_ = 32, Key INVALID_KEY_ = ~Key{0}, typename SizeType = unsigned int>
 class TSlotMap
 {
     // Compile time pow function
@@ -58,15 +58,15 @@ public:
     using GenType      = SizeType;
     using IndexType    = SizeType;
 
-    static const Key INVALID_KEY = INVALID_KEY;
+    static constexpr Key INVALID_KEY = INVALID_KEY_;
 
     // Generation | Index (Into index array or data array. Into data array if slot is unused to point to next free slot)
-    static const unsigned int GENERATION_BIT_COUNT = GENERATION_BIT_COUNT;
-    static const unsigned int INDEX_BIT_COUNT      = INDEX_BIT_COUNT;
+    static constexpr unsigned int GENERATION_BIT_COUNT = GENERATION_BIT_COUNT_;
+    static constexpr unsigned int INDEX_BIT_COUNT      = INDEX_BIT_COUNT_;
 
     // Masks to retrieve the generation or index from a key
-    static const IndexGenType GENERATION_BIT_MASK = POW<IndexGenType>(2, GENERATION_BIT_COUNT) - 1;
-    static const IndexGenType INDEX_BIT_MASK      = POW<IndexGenType>(2, INDEX_BIT_COUNT) - 1;
+    static constexpr IndexGenType GENERATION_BIT_MASK = POW<IndexGenType>(2, GENERATION_BIT_COUNT) - 1;
+    static constexpr IndexGenType INDEX_BIT_MASK      = POW<IndexGenType>(2, INDEX_BIT_COUNT) - 1;
 
     static_assert(INDEX_BIT_COUNT <= sizeof(IndexType) * 8,
         "Index bit-count is too high, because SizeType can not represent it. Consider another type for SizeType or decrease the index bit-count.");

--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -38,10 +38,10 @@
 // @Key: Type is used as a key and contains the Index for the data array and a generation counter (to solve ABA problem)
 // @INDEX_BIT_COUNT: Number of bits for the index into the index map. This specifies an upper limit for the entry count.
 // @GENERATION_BIT_COUNT: Number of bits for the generation. If this value is too low, ABA problem is more likely to happen.
-// @INVALID_KEY: It is guaranteed that this key will never be generated and can safely be used to represent something like INVALID.
+// @INVALID_KEY: It is guaranteed that this key will never be generated and can safely be used to represent something like INVALID. Currently it's value the same as: std::numeric_limit<Key>::max()
 // @SizeType: Type for the erase-table. The slot-map can not contain more entries than the number of elements this number can represent.
 // NOTE: INDEX_BIT_COUNT + GENERATION_BIT_COUNT MUST be equal to the amount of bits in Key. (Ensured by static assert)
-template<typename Value, typename Key = uint64_t, unsigned int INDEX_BIT_COUNT = 32, unsigned int GENERATION_BIT_COUNT = 32, Key INVALID_KEY = ~0, typename SizeType = unsigned int>
+template<typename Value, typename Key = uint64_t, unsigned int INDEX_BIT_COUNT = 32, unsigned int GENERATION_BIT_COUNT = 32, Key INVALID_KEY = ~Key{0}, typename SizeType = unsigned int>
 class TSlotMap
 {
     // Compile time pow function

--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -368,7 +368,7 @@ private:
     void _Destroy()
     {
         for (unsigned int i = 0; i < size(); i++)
-            _DeconstructObject(m_Data, i),
+            _DeconstructObject(m_Data, i);
 
         free(m_Data);
         delete[] m_IndicesAndGeneration;

--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -434,7 +434,7 @@ private:
 
     //////////////////////////////////////////////////////////////////////////////
     template <typename T>
-    inline typename std::enable_if<std::is_trivially_destructible<T>::value>::type _DeconstructObject(T* src, IndexType index)
+    inline typename std::enable_if<std::is_trivially_destructible<T>::value>::type _DeconstructObject(T* /*src*/, IndexType /*index*/)
     {
         // Do nothing
     }

--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -30,8 +30,10 @@
 **********************************************************************/
 
 #include <type_traits>
-#include <cstring>
-#include <cassert>
+#include <cstring> // for: memset(), memcpy()
+#include <cstdint> // for: uint64_t
+#include <memory>  // for: std::addressof() 
+#include <cassert> // for: assert()
 
 // Slot-Map data-structure with O(1) insert, erase and fast iteration/lookup
 // @Value: Type of data contained in this slot map.

--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -36,14 +36,16 @@
 #include <memory>  // for: std::addressof() 
 #include <cassert> // for: assert()
 
-// Slot-Map data-structure with O(1) insert, erase and fast iteration/lookup
-// @Value: Type of data contained in this slot map.
-// @Key: Type is used as a key and contains the Index for the data array and a generation counter (to solve ABA problem)
-// @INDEX_BIT_COUNT_: Number of bits for the index into the index map. This specifies an upper limit for the entry count.
-// @GENERATION_BIT_COUNT_: Number of bits for the generation. If this value is too low, ABA problem is more likely to happen.
-// @INVALID_KEY_: It is guaranteed that this key will never be generated and can safely be used to represent something like INVALID. Currently it's value the same as: std::numeric_limit<Key>::max()
-// @SizeType: Type for the erase-table. The slot-map can not contain more entries than the number of elements this number can represent.
-// NOTE: INDEX_BIT_COUNT_ + GENERATION_BIT_COUNT_ MUST be equal to the amount of bits in Key. (Ensured by static assert)
+/// @brief Slot-Map data-structure with O(1) insert, erase and fast iteration/lookup
+///
+/// @tparam Value Type of data contained in this slot map.
+/// @tparam Key Type is used as a key and contains the Index for the data array and a generation counter (to solve ABA problem)
+/// @tparam INDEX_BIT_COUNT_ Number of bits for the index into the index map. This specifies an upper limit for the entry count.
+/// @tparam GENERATION_BIT_COUNT_ Number of bits for the generation. If this value is too low, ABA problem is more likely to happen.
+/// @tparam INVALID_KEY_ It is guaranteed that this key will never be generated and can safely be used to represent something like INVALID. Currently it's value the same as: `std::numeric_limit<Key>::max()`
+/// @tparam SizeType Type for the erase-table. The slot-map can not contain more entries than the number of elements this number can represent.
+///
+/// @note INDEX_BIT_COUNT_ + GENERATION_BIT_COUNT_ MUST be equal to the amount of bits in Key. (Ensured by static assert)
 template <typename Value, typename Key = uint64_t, unsigned int INDEX_BIT_COUNT_ = 32, unsigned int GENERATION_BIT_COUNT_ = 32, Key INVALID_KEY_ = ~Key{0}, typename SizeType = unsigned int>
 class TSlotMap
 {


### PR DESCRIPTION
I found this library is simple & beautiful, so tried it in my pet-project. But using it on linux with `gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0` and `--std=c++11` not work well. 

This pull request fixes the next things:
- `Key INVALID_KEY = ~Key{0}` - now contains proper value & compiled without error
- static member values {`INVALID_KEY`, `GENERATION_BIT_COUNT`, `INDEX_BIT_COUNT`} not shadow template arguments
- `const Value* at(Key key) const {` now work ok. `return const_cast<TSlotMap*>(this)->at(key);` in it now explicetly show us, that we want to use `non-const` func call in `const` context.
- in `void _Destroy()` used `_DeconstructObject(m_Data, i);` (with semicolon in end) not `_DeconstructObject(m_Data, i),` (comma in end).