### PR TITLE
Update slot_map.h - fixed warning: 'left shift count >= width of type'

### DIFF
--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -288,7 +288,7 @@ private:
     void _SetGeneration(IndexGenType& val, GenType gen)
     {
         val &= ~(GENERATION_BIT_MASK << INDEX_BIT_COUNT); // erases all generation bits
-        val |= gen << INDEX_BIT_COUNT;
+        val |= static_cast<IndexGenType>(gen) << INDEX_BIT_COUNT;
     }
 
     void _SetIndex(IndexGenType& val, IndexType index)


### PR DESCRIPTION
`gcc (Ubuntu 11.3.0-1ubuntu1~22.04.1) 11.3.0` produces the next warning:

```
SlotMap/slot_map.h:303:20: warning: left shift count >= width of type [-Wshift-count-overflow]
  303 |         val |= gen << INDEX_BIT_COUNT;
      |                ~~~~^~~~~~~~~~~~~~~~~~
```

At this line (303):

```cpp
void _SetGeneration(IndexGenType& val, GenType gen)
{
    val &= ~(GENERATION_BIT_MASK << INDEX_BIT_COUNT); // erases all generation bits
    val |= gen << INDEX_BIT_COUNT;
}
```
with default template values it may be unwrapped as:
```cpp
using IndexGenType = Key; // --> uint64_t
using GenType      = SizeType; // --> unsinged int

constexpr unsigned int INDEX_BIT_COUNT = 32;
constexpr IndexGenType GENERATION_BIT_MASK = 4294967295; // --> 0xFFFFFFFF

void _SetGeneration(IndexGenType& val, GenType gen)
{
    val &= ~(GENERATION_BIT_MASK << INDEX_BIT_COUNT); // erases all generation bits
    val |= gen << INDEX_BIT_COUNT;
}
```
or even more, if use types & values directly:
```cpp
void _SetGeneration(uint64_t& val, unsigned int gen)
{
    val &= ~(uint64_t{0xFFFFFFFF} << 32); // erases all generation bits
    val |= gen << 32;
}
```

----

During investigation, where may be the problem, I found [StackOverflow answer](https://stackoverflow.com/a/68889813/) with similar code:
```cpp
uint64_t tsc = 0xdeaddeadc0dec0de;
uint32_t MSB = tsc >> 32;
uint32_t LSB = tsc;
uint64_t MLSB = LSB | (static_cast<uint64_t>(MSB)) << 32;
uint64_t LMSB = MSB | (static_cast<uint64_t>(LSB)) << 32;
```

So, as I can see, inside of `_SetGeneration`  missed `static_cast` - in our case `gen` is `unsigned int` and must be casted into `val` type - `IndexGenType` **before** bit-shift. 

That was added in this PR :) (and my compiler dont warn on this line anymore)