### PR TITLE
Added missing <cstdlib> include for: malloc(), free()

### DIFF
--- a/SlotMap/slot_map.h
+++ b/SlotMap/slot_map.h
@@ -31,6 +31,7 @@
 **********************************************************************/
 
 #include <type_traits>
+#include <cstdlib> // for: malloc(), free()
 #include <cstring> // for: memset(), memcpy()
 #include <cstdint> // for: uint64_t
 #include <memory>  // for: std::addressof() 


### PR DESCRIPTION
During build of this library with `cmake <...> -DCMAKE_BUILD_TYPE=Release`,  `gcc (Ubuntu 11.3.0-1ubuntu1~22.04.1) 11.3.0` produces the next errors:

```
SlotMap/slot_map.h:409:32: error: ‘malloc’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
  409 |         m_Data = (Value*)malloc(m_Capacity * sizeof(Value));
      |                          ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
SlotMap/slot_map.h:390:13: error: ‘free’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
  390 |         free(m_Data);
```

In this PR added missing include `<cstdlib>`, that contains this functions :)